### PR TITLE
add prettier for imports

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,5 @@
   "tabWidth": 2,
   "singleQuote": true,
   "jsxSingleQuote": true,
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss", "prettier-plugin-organize-imports"]
 }

--- a/app/add-workplace/page.tsx
+++ b/app/add-workplace/page.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import AddWorkplace from '../components/addSpaceComponents/NewWorplace';
+import { Database } from '@/database.types';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
-import { Database } from '@/database.types';
+import AddWorkplace from '../components/addSpaceComponents/NewWorplace';
 
 const FormAddingWorkplace = async () => {
   const cookieStore = cookies();

--- a/app/cities/[id]/page.tsx
+++ b/app/cities/[id]/page.tsx
@@ -1,7 +1,7 @@
-import { CityData, PageByIDParams } from '@/app/utils/types';
 import Navbar from '@/app/components/NavBar';
-import allData from '@/app/utils/getData';
 import DisplayCityPage from '@/app/components/cityPageComponents/DisplayCityPage';
+import allData from '@/app/utils/getData';
+import { CityData, PageByIDParams } from '@/app/utils/types';
 import { Database } from '@/database.types';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';

--- a/app/components/Carousel.tsx
+++ b/app/components/Carousel.tsx
@@ -1,7 +1,7 @@
 'use client';
-import React, { useState } from 'react';
-import { DisplayPlaceCard } from './DisplayPlaceCard';
 import { Button, Flex, Heading } from '@radix-ui/themes';
+import { useState } from 'react';
+import { DisplayPlaceCard } from './DisplayPlaceCard';
 
 export default function Carousel({ title, data }: any) {
   function addToSlide() {
@@ -51,12 +51,12 @@ export default function Carousel({ title, data }: any) {
         gap='9'
       >
         <div className='mt-5 flex justify-end'>
-        <Button onClick={() => subtractFromSlide()} size='3'>
-          Prev
-        </Button>
-        <Button onClick={() => addToSlide()} size='3'>
-          Next
-        </Button>
+          <Button onClick={() => subtractFromSlide()} size='3'>
+            Prev
+          </Button>
+          <Button onClick={() => addToSlide()} size='3'>
+            Next
+          </Button>
         </div>
       </Flex>
     </Flex>

--- a/app/components/DisplayCities.tsx
+++ b/app/components/DisplayCities.tsx
@@ -1,8 +1,8 @@
-import { SupabaseCall } from '@/utils/supabaseCall';
-import Carousel from './Carousel';
 import { City, WorkspaceWithReviews } from '@/app/utils/types';
-import { SearchBar } from './homePageComponents/SearchBar';
+import { SupabaseCall } from '@/utils/supabaseCall';
 import { Flex } from '@radix-ui/themes';
+import Carousel from './Carousel';
+import { SearchBar } from './homePageComponents/SearchBar';
 
 const DisplayCities = async () => {
   const cities: City[] =

--- a/app/components/DisplayPlaceCard.tsx
+++ b/app/components/DisplayPlaceCard.tsx
@@ -1,15 +1,15 @@
-import Link from 'next/link';
+import { getColorByKey } from '@/app/utils/getColor';
+import { PlaceCardParams } from '@/app/utils/types';
 import {
   Avatar,
+  Badge,
   Box,
   Card,
+  Container,
   Flex,
   Text,
-  Badge,
-  Container,
 } from '@radix-ui/themes';
-import { PlaceCardParams } from '@/app/utils/types';
-import { getColorByKey } from '@/app/utils/getColor';
+import Link from 'next/link';
 
 export function DisplayPlaceCard({
   pageRoute,

--- a/app/components/DisplayWishlistPlaces.tsx
+++ b/app/components/DisplayWishlistPlaces.tsx
@@ -1,9 +1,7 @@
 'use client';
-import React from 'react';
-import { Amenities } from '../utils/types';
-import { Heading, Flex } from '@radix-ui/themes';
-import { WishlistDisplay } from '../utils/types';
 import { DisplayPlaceCard } from '@/app/components/DisplayPlaceCard';
+import { Flex, Heading } from '@radix-ui/themes';
+import { Amenities, WishlistDisplay } from '../utils/types';
 
 export default function DisplayWishlistPlaces({
   places,

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { Button } from '@radix-ui/themes';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Button } from '@radix-ui/themes';
+import { useState } from 'react';
 
 export default function NavBar({ user }: { user: string | null }) {
   const [isMenuOpen, setMenuOpen] = useState(false);

--- a/app/components/addSpaceComponents/AmenitiesCheckBox.tsx
+++ b/app/components/addSpaceComponents/AmenitiesCheckBox.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { Text, Strong, Checkbox, Heading } from '@radix-ui/themes';
 import * as Label from '@radix-ui/react-label';
+import { Checkbox, Heading, Strong, Text } from '@radix-ui/themes';
+import React from 'react';
 
 interface AmenitiesCheckboxesProps {
   selectedAmenities: string[];

--- a/app/components/addSpaceComponents/CustomTextField.tsx
+++ b/app/components/addSpaceComponents/CustomTextField.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { TextField } from '@radix-ui/themes';
+import React from 'react';
 import ErrorMessage from './ErrorMessage';
 
 interface CustomTextFieldProps {

--- a/app/components/addSpaceComponents/ErrorMessage.tsx
+++ b/app/components/addSpaceComponents/ErrorMessage.tsx
@@ -1,5 +1,5 @@
-import React, { PropsWithChildren } from 'react';
 import { Text } from '@radix-ui/themes';
+import { PropsWithChildren } from 'react';
 
 const ErrorMessage = ({ children }: PropsWithChildren) => {
   if (!children) return null;

--- a/app/components/addSpaceComponents/NewWorplace.tsx
+++ b/app/components/addSpaceComponents/NewWorplace.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import { Heading, Button, Callout } from '@radix-ui/themes';
-import { useForm } from 'react-hook-form';
-import { CreateAddWorkplaceForm } from './validationForm';
-import Spinner from './Spiner';
-import NavBar from '../NavBar';
-import SelectCity from './SelectCity';
-import CustomTextField from './CustomTextField';
-import AmenitiesCheckboxes from './AmenitiesCheckBox';
 import {
   useAmenityHandling,
   useCityHandling,
   useSubmitHandling,
 } from '@/app/lib/useAddWorkSpace';
+import { Button, Callout, Heading } from '@radix-ui/themes';
+import { useForm } from 'react-hook-form';
+import NavBar from '../NavBar';
+import AmenitiesCheckboxes from './AmenitiesCheckBox';
+import CustomTextField from './CustomTextField';
+import SelectCity from './SelectCity';
+import Spinner from './Spiner';
+import { CreateAddWorkplaceForm } from './validationForm';
 
 export default function AddWorkplace({ user }: { user: any | null }) {
   const {

--- a/app/components/addSpaceComponents/ReviewWorkplace.tsx
+++ b/app/components/addSpaceComponents/ReviewWorkplace.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const ReviewWorkplace = () => {
   return (
     <div>

--- a/app/components/addSpaceComponents/SelectCity.tsx
+++ b/app/components/addSpaceComponents/SelectCity.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { Select } from '@radix-ui/themes';
 import { citiesWithId } from '@/app/utils/constants';
+import { Select } from '@radix-ui/themes';
+import React from 'react';
 
 interface CitySelectProps {
   value: string;

--- a/app/components/addSpaceComponents/Spiner.tsx
+++ b/app/components/addSpaceComponents/Spiner.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Spinner = () => {
   return (
     <div

--- a/app/components/authPageComponents/AuthForm.tsx
+++ b/app/components/authPageComponents/AuthForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button, TextField, Flex, Heading } from '@radix-ui/themes';
 import { FormInputProps } from '@/app/utils/types';
+import { Button, Heading, TextField } from '@radix-ui/themes';
 
 const FormInput: React.FC<FormInputProps> = ({ name, type, placeholder }) => {
   return (

--- a/app/components/cityPageComponents/CityHeader.tsx
+++ b/app/components/cityPageComponents/CityHeader.tsx
@@ -1,4 +1,4 @@
-import { Heading, Text, Box } from '@radix-ui/themes';
+import { Box, Heading, Text } from '@radix-ui/themes';
 
 export default function CityHeader({ city }: { city: any }) {
   return (

--- a/app/components/cityPageComponents/DisplayCityPage.tsx
+++ b/app/components/cityPageComponents/DisplayCityPage.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useState } from 'react';
 
-import { Heading, Flex } from '@radix-ui/themes';
-import { CityData } from '@/app/utils/types';
 import { DisplayPlaceCard } from '@/app/components/DisplayPlaceCard';
-import FilterButtons from './FilterButtons';
+import { CityData } from '@/app/utils/types';
+import { Flex, Heading } from '@radix-ui/themes';
 import CityHeader from './CityHeader';
+import FilterButtons from './FilterButtons';
 
 export default function DisplayCityPage({
   city,

--- a/app/components/cityPageComponents/FilterButtons.tsx
+++ b/app/components/cityPageComponents/FilterButtons.tsx
@@ -1,6 +1,6 @@
-import { Button, Grid, Text } from '@radix-ui/themes';
+import { allAmenities, amenityOptions } from '@/app/utils/constants';
 import { getColorByKey } from '@/app/utils/getColor';
-import { amenityOptions, allAmenities } from '@/app/utils/constants';
+import { Button, Grid, Text } from '@radix-ui/themes';
 
 export default function FilterButtons({ setSelectedFilter }: any) {
   return (

--- a/app/components/detailPageComponents/AddToWishlist.tsx
+++ b/app/components/detailPageComponents/AddToWishlist.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { SupabaseCall } from '@/utils/supabaseCall';
-import newClient from '../../config/supabaseclient';
-import Link from 'next/link';
 import { Button } from '@radix-ui/themes';
+import Link from 'next/link';
+import newClient from '../../config/supabaseclient';
 import { Profile } from '../../utils/types';
 
 export default function AddToWishList({

--- a/app/components/detailPageComponents/MapView.tsx
+++ b/app/components/detailPageComponents/MapView.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import * as React from 'react';
-import Map, { Marker } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
+import Map, { Marker } from 'react-map-gl';
 
 const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
 

--- a/app/components/detailPageComponents/SeeMore.tsx
+++ b/app/components/detailPageComponents/SeeMore.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { Button, Text } from '@radix-ui/themes';
-import React, { useState } from 'react';
+import { Button } from '@radix-ui/themes';
+import { useState } from 'react';
 export default function SeeMore(props: any) {
   const place = props.place[0];
   const [show, setShow] = useState(false);

--- a/app/components/homePageComponents/SearchBar.tsx
+++ b/app/components/homePageComponents/SearchBar.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { FaSearch } from 'react-icons/fa';
 import { TextField } from '@radix-ui/themes';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { FaSearch } from 'react-icons/fa';
 
 export const SearchBar: React.FC<{
   cities: { id: number; name: string | null }[];

--- a/app/config/supabaseclient.ts
+++ b/app/config/supabaseclient.ts
@@ -1,4 +1,4 @@
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js';
 
 const newClient = () => {
   const supabaseUrl: string | undefined = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/app/error/page.tsx
+++ b/app/error/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
+import { Blockquote, Heading } from '@radix-ui/themes';
 import { useSearchParams } from 'next/navigation';
-import { Heading, Blockquote } from '@radix-ui/themes';
+import { useEffect } from 'react';
 
 const ErrorPage: React.FC = () => {
   const searchParams = useSearchParams();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,9 @@
+import { Theme } from '@radix-ui/themes';
+import '@radix-ui/themes/styles.css';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
-import '@radix-ui/themes/styles.css';
 import './theme-config.css';
-import { Theme } from '@radix-ui/themes';
 
 const inter = Inter({
   subsets: ['latin'],

--- a/app/lib/useAddWorkSpace.ts
+++ b/app/lib/useAddWorkSpace.ts
@@ -1,8 +1,8 @@
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { CreateAddWorkplaceForm } from '@/app/components/addSpaceComponents/validationForm';
 import newClient from '@/app/config/supabaseclient';
 import { citiesWithId } from '@/app/utils/constants';
-import { CreateAddWorkplaceForm } from '@/app/components/addSpaceComponents/validationForm';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 export function useAmenityHandling() {
   const [selectedAmenities, setSelectedAmenities] = useState<string[]>([]);

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,9 +1,9 @@
-import WholeForm from '../components/authPageComponents/AuthForm';
-import Navbar from '../components/NavBar';
 import { Heading } from '@radix-ui/themes';
-import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
 import { Database } from '../../database.types';
+import Navbar from '../components/NavBar';
+import WholeForm from '../components/authPageComponents/AuthForm';
 
 export default async function Login() {
   const cookieStore = cookies();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,10 @@
-import DisplayCities from './components/DisplayCities';
 import Navbar from '@/app/components/NavBar';
+import { Database } from '@/database.types';
 import { Heading } from '@radix-ui/themes';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
+import DisplayCities from './components/DisplayCities';
 import { PageByIDParams } from './utils/types';
-import { Database } from '@/database.types';
 
 export default async function ServerComponent({ params }: PageByIDParams) {
   const cookieStore = cookies();

--- a/app/places/[id]/page.tsx
+++ b/app/places/[id]/page.tsx
@@ -1,16 +1,14 @@
+import { DisplayPlaceCard } from '@/app/components/DisplayPlaceCard';
+import Navbar from '@/app/components/NavBar';
+import AddToWishList from '@/app/components/detailPageComponents/AddToWishlist';
+import { MapView } from '@/app/components/detailPageComponents/MapView';
 import SeeMore from '@/app/components/detailPageComponents/SeeMore';
 import { PageByIDParams, Workspace } from '@/app/utils/types';
 import { SupabaseCall } from '@/utils/supabaseCall';
-import Link from 'next/link';
-import Navbar from '@/app/components/NavBar';
-import AddToWishList from '@/app/components/detailPageComponents/AddToWishlist';
-import { cookies } from 'next/headers';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import Link from 'next/link';
 import { Database } from '../../../database.types';
-import { DisplayPlaceCard } from '@/app/components/DisplayPlaceCard';
-import { Button } from '@radix-ui/themes';
-import { MapView } from '@/app/components/detailPageComponents/MapView';
-import { Heading, Text } from '@radix-ui/themes';
 
 export default async function WorkSpaces({ params }: PageByIDParams) {
   let place: Workspace[] | null = null;

--- a/app/sentry-example-page/page.jsx
+++ b/app/sentry-example-page/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
-import Head from 'next/head';
 import * as Sentry from '@sentry/nextjs';
+import Head from 'next/head';
 
 export default function Page() {
   return (

--- a/app/utils/getData.ts
+++ b/app/utils/getData.ts
@@ -1,5 +1,5 @@
+import { Amenities, CityPage } from '@/app/utils/types';
 import { SupabaseCall } from '@/utils/supabaseCall';
-import { CityPage, Amenities } from '@/app/utils/types';
 
 export default async function getAmenities(id: string) {
   let city: CityPage[] | null = null;

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -1,4 +1,3 @@
-import { type } from 'os';
 import { Database } from '../../database.types';
 
 export type CheckboxProps = {

--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -1,11 +1,11 @@
-import { Workspace, Profile } from '@/app/utils/types';
-import { SupabaseCall } from '@/utils/supabaseCall';
 import Navbar from '@/app/components/NavBar';
-import { cookies } from 'next/headers';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { Profile, Workspace } from '@/app/utils/types';
 import { Database } from '@/database.types';
-import DisplayWishlistPlaces from '../components/DisplayWishlistPlaces';
+import { SupabaseCall } from '@/utils/supabaseCall';
 import { Heading } from '@radix-ui/themes';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import DisplayWishlistPlaces from '../components/DisplayWishlistPlaces';
 
 export default async function wishlist() {
   const cookieStore = cookies();

--- a/e2e/cities.spec.ts
+++ b/e2e/cities.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('http://localhost:3000');

--- a/e2e/landing-page.spec.ts
+++ b/e2e/landing-page.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('http://localhost:3000/');

--- a/e2e/navbar.spec.ts
+++ b/e2e/navbar.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('http://localhost:3000/login');

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "lint-staged": "^15.0.2",
     "@flydotio/dockerfile": "^0.4.10",
     "@playwright/test": "^1.39.0",
     "@types/node": "^20",
@@ -44,8 +43,10 @@
     "eslint-config-next": "14.0.1",
     "eslint-config-prettier": "^9.0.0",
     "husky": "^8.0.3",
+    "lint-staged": "^15.0.2",
     "postcss": "^8",
     "prettier": "^3.0.3",
+    "prettier-plugin-organize-imports": "^3.2.4",
     "prettier-plugin-tailwindcss": "^0.5.6",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.2.2"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,9 +15,9 @@ const config: Config = {
       },
     },
     screens: {
-      'sm': '640px',
-      'md': '768px'
-    }
+      sm: '640px',
+      md: '768px',
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Prettier has this nifty package for managing imports - I've run `format:fix` to show the difference it makes to keeping files tidy, but ofc you can just install [the library](https://www.npmjs.com/package/prettier-plugin-organize-imports) and include in the prettier config